### PR TITLE
Don't depend on NRPE Plugin where only Server is required.

### DIFF
--- a/nagios/nrpe/dynamic.sls
+++ b/nagios/nrpe/dynamic.sls
@@ -15,7 +15,6 @@
 
 include:
   - .server
-  - .plugin
 
 {% if salt['pillar.get']("nagios:checks", False) %}
 {% for check_name, check_def in salt['pillar.get']("nagios:checks").items() %}
@@ -34,7 +33,7 @@ include:
     - name: {{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }}
 {%- endif %}
     - require:
-      - pkg: nrpe-plugin-package
+      - pkg: nrpe-server-package
 {% endif %}  # plugin_file in check_def['plugin']
 {% endif %}  # decommed
 
@@ -47,10 +46,10 @@ clear decommissioned {{ check_name }} nrpe command:
 {{ check_name }} nrpe command definition:
   file.managed:
     - name: {{ nrpe.cfg_dir }}/{{ check_name }}.cfg
-    - contents: |
+    - contents: server
         command[{{ check_name }}]={{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }} {{ check_def['plugin'].get('plugin_args', "") }}
     - require:
-      - pkg: nrpe-plugin-package
+      - pkg: nrpe-server-package
       - file: {{ nrpe.cfg_dir }}
     - watch_in:
       - service: nrpe-server-service


### PR DESCRIPTION
Nagios NRPE Plugin is the server-side plugin that's used as the NRPE
client and doesn't need to be installed on remote hosts where only the
Nagios NRPE Server is required.
